### PR TITLE
Validate Volk global dispatch initialization

### DIFF
--- a/c/loader_bridge.h
+++ b/c/loader_bridge.h
@@ -1,0 +1,23 @@
+#pragma once
+
+// Keep initialization and validation in the translation unit that owns Volk's
+// global dispatch table. Some Linux loader/SDK combinations report success from
+// volkInitialize() while leaving vkCreateInstance unresolved.
+static VkResult v_vulkan_initialize_loader(void) {
+	VkResult result = volkInitialize();
+	if (result != VK_SUCCESS || vkCreateInstance != NULL) {
+		return result;
+	}
+
+#if defined(__linux__)
+	void *loader = dlopen("libvulkan.so.1", RTLD_NOW | RTLD_LOCAL);
+	if (loader == NULL) {
+		loader = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);
+	}
+	if (loader != NULL) {
+		vkCreateInstance = (PFN_vkCreateInstance)dlsym(loader, "vkCreateInstance");
+	}
+#endif
+
+	return vkCreateInstance != NULL ? VK_SUCCESS : VK_ERROR_INITIALIZATION_FAILED;
+}

--- a/c/volk.c.v
+++ b/c/volk.c.v
@@ -9,3 +9,4 @@ module c
 #define VK_NO_PROTOTYPES
 #define VOLK_IMPLEMENTATION
 #include <volk.h>
+#include "loader_bridge.h"

--- a/loader.v
+++ b/loader.v
@@ -1,9 +1,11 @@
 module vulkan
 
+fn C.v_vulkan_initialize_loader() Result
+
 // initialize_loader loads the Vulkan loader and populates the global commands.
 // Call this before create_instance().
 pub fn initialize_loader() Result {
-	return C.volkInitialize()
+	return C.v_vulkan_initialize_loader()
 }
 
 // load_instance_commands populates commands that are scoped to an instance.


### PR DESCRIPTION
Initialize and validate Volk in the C translation unit that owns its global dispatch table. On Linux, recover vkCreateInstance directly from the Vulkan loader when volkInitialize reports success without resolving it; otherwise return VK_ERROR_INITIALIZATION_FAILED instead of permitting a null dispatch call.