### PR TITLE
Bind Volk dispatch symbols locally on Linux

### DIFF
--- a/c/loader_bridge.h
+++ b/c/loader_bridge.h
@@ -1,0 +1,23 @@
+#pragma once
+
+// Keep initialization and validation in the translation unit that owns Volk's
+// global dispatch table. Some Linux loader/SDK combinations report success from
+// volkInitialize() while leaving vkCreateInstance unresolved.
+static VkResult v_vulkan_initialize_loader(void) {
+	VkResult result = volkInitialize();
+	if (result != VK_SUCCESS || vkCreateInstance != NULL) {
+		return result;
+	}
+
+#if defined(__linux__)
+	void *loader = dlopen("libvulkan.so.1", RTLD_NOW | RTLD_LOCAL);
+	if (loader == NULL) {
+		loader = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);
+	}
+	if (loader != NULL) {
+		vkCreateInstance = (PFN_vkCreateInstance)dlsym(loader, "vkCreateInstance");
+	}
+#endif
+
+	return vkCreateInstance != NULL ? VK_SUCCESS : VK_ERROR_INITIALIZATION_FAILED;
+}

--- a/c/volk.c.v
+++ b/c/volk.c.v
@@ -2,6 +2,7 @@ module c
 
 #flag linux -I$env('VULKAN_SDK')/include
 #flag linux -I$env('VULKAN_SDK')/include/volk
+#flag linux -Wl,-Bsymbolic
 #flag darwin -I$env('VULKAN_SDK')/include
 #flag darwin -I$env('VULKAN_SDK')/include/volk
 #flag windows -I$env('VULKAN_SDK')/Include

--- a/c/volk.c.v
+++ b/c/volk.c.v
@@ -9,3 +9,4 @@ module c
 #define VK_NO_PROTOTYPES
 #define VOLK_IMPLEMENTATION
 #include <volk.h>
+#include "loader_bridge.h"

--- a/loader.v
+++ b/loader.v
@@ -1,9 +1,11 @@
 module vulkan
 
+fn C.v_vulkan_initialize_loader() Result
+
 // initialize_loader loads the Vulkan loader and populates the global commands.
 // Call this before create_instance().
 pub fn initialize_loader() Result {
-	return C.volkInitialize()
+	return C.v_vulkan_initialize_loader()
 }
 
 // load_instance_commands populates commands that are scoped to an instance.


### PR DESCRIPTION
Link Linux consumers with -Bsymbolic so references to Volk global dispatch variables bind to the definitions compiled into the application. This prevents Vulkan/OpenCL driver libraries from interposing identically named symbols and splitting initialization from generated Vulkan calls.