### PR TITLE
Adopt canonical Vulkan VPM paths

### DIFF
--- a/.github/workflows/generated-bindings-ci.yml
+++ b/.github/workflows/generated-bindings-ci.yml
@@ -76,14 +76,14 @@ jobs:
       - name: Download Volk and compile smoke test
         run: |
           set -euo pipefail
-          install -d "$VULKAN_SDK/include/volk" "$HOME/.vmodules"
+          install -d "$VULKAN_SDK/include/volk" "$HOME/.vmodules/antono2"
           curl --fail --silent --show-error --location \
             https://raw.githubusercontent.com/zeux/volk/master/volk.h \
             --output "$VULKAN_SDK/include/volk/volk.h"
           curl --fail --silent --show-error --location \
             https://raw.githubusercontent.com/zeux/volk/master/volk.c \
             --output "$VULKAN_SDK/include/volk/volk.c"
-          ln -s "$GITHUB_WORKSPACE" "$HOME/.vmodules/vulkan"
+          ln -s "$GITHUB_WORKSPACE" "$HOME/.vmodules/antono2/vulkan"
           v -cc gcc run generator/test
 
   tag-release:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Please install the [Vulkan SDK](https://vulkan.lunarg.com/sdk/home) and set the 
 Download the latest bindings to your local `.vmodules` directory:
 
 ```
-v install https://github.com/antono2/vulkan
+v install antono2.vulkan
 ```
 
 Applications using the binding directly must initialize Volk before the first
@@ -18,13 +18,15 @@ Vulkan call, then load instance- and device-level commands after creating the
 corresponding handles:
 
 ```v
-if vulkan.initialize_loader() != .success {
+import antono2.vulkan as vk
+
+if vk.initialize_loader() != .success {
 	panic('Vulkan loader initialization failed')
 }
 // create the Vulkan instance
-vulkan.load_instance_commands(instance)
+vk.load_instance_commands(instance)
 // create the Vulkan device
-vulkan.load_device_commands(device)
+vk.load_device_commands(device)
 ```
 
 ### Historical Vulkan versions

--- a/v.mod
+++ b/v.mod
@@ -1,5 +1,5 @@
 Module {
-	name: 'vulkan'
+	name: 'antono2.vulkan'
 	author: 'Anton Oreskin'
 	description: 'V Vulkan Bindings'
 	version: '1.0.0'


### PR DESCRIPTION
Use the canonical antono2.vulkan package identity in the manifest and documentation, and assemble the generated-bindings CI smoke test under .vmodules/antono2/vulkan. The source module remains vulkan, preserving compatibility with both flat and namespaced module directories.