### PR TITLE
Add ergonomic Vulkan discovery API

### DIFF
--- a/.github/workflows/generated-bindings-ci.yml
+++ b/.github/workflows/generated-bindings-ci.yml
@@ -85,6 +85,7 @@ jobs:
             --output "$VULKAN_SDK/include/volk/volk.c"
           ln -s "$GITHUB_WORKSPACE" "$HOME/.vmodules/antono2/vulkan"
           v -cc gcc run generator/test
+          v -cc gcc test ergonomic
 
   tag-release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/API_DESIGN.md
+++ b/API_DESIGN.md
@@ -1,0 +1,46 @@
+# Ergonomic Vulkan API
+
+The generated `vulkan.v` and `vulkan_video.v` files remain the complete, low-level API. Hand-written conveniences live in the opt-in `antono2.vulkan.ergonomic` submodule so registry regeneration cannot overwrite them and existing programs do not change behavior.
+
+## Conventions
+
+- Raw Vulkan handles remain available through a public `handle` field. Wrappers do not hide escape hatches needed for extensions or interoperability.
+- A negative `VkResult` becomes a typed `VulkanError` containing both the original result and the operation name. `check` preserves non-negative statuses; `require_success` enforces exact success where that is the operation's contract.
+- Constructors return V results (`!T`) and perform required loader/dispatch setup.
+- Vulkan objects use explicit `destroy()` methods. There are no implicit finalizers, and each successfully created owned object must be destroyed exactly once.
+- Two-call enumerations return V arrays and internally retry `VK_INCOMPLETE`.
+- Generated names and signatures are never edited to improve ergonomics. New wrappers compose them from the submodule.
+
+## First slice
+
+The first slice covers loader initialization, default-allocator instance creation and destruction, physical-device enumeration, core property snapshots, and owned device-name strings:
+
+```v
+import antono2.vulkan as vk
+import antono2.vulkan.ergonomic as vke
+
+app := vk.ApplicationInfo{
+	pApplicationName: c'my app'
+	apiVersion: vk.api_version_1_0
+}
+info := vk.InstanceCreateInfo{
+	pApplicationInfo: &app
+}
+instance := vke.new_instance(&info)!
+defer {
+	instance.destroy()
+}
+for device in instance.physical_devices()! {
+	println('${device.name()} (${device.properties.vendorID:04x}:${device.properties.deviceID:04x})')
+}
+```
+
+Custom allocation callbacks deliberately remain in the raw layer for now. A future owning wrapper must retain the allocator used at creation so the same callbacks are supplied during destruction.
+
+## Next slices
+
+1. Instance extension and layer enumeration with owned V strings.
+2. Queue-family discovery and selection helpers that express required flags and presentation support.
+3. Logical-device creation with queue requests, extension validation, and instance/device dispatch loading.
+4. Owned buffers, images, command pools, and synchronization objects, each with explicit parent ownership and destruction ordering.
+5. Builders only where they eliminate unsafe pointer/count bookkeeping; Vulkan synchronization and memory choices should remain explicit.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ compatibility suffix.
 An example can be found at  [antono2/v_vulkan_bindings/test](https://github.com/antono2/v_vulkan_bindings/tree/master/test)</br>
 Using GLFW and Dear ImGui [antono2/v_imgui_examples](https://github.com/antono2/v_imgui_examples)
 
+## Ergonomic API (opt in)
+
+The generated module remains the complete low-level binding. The opt-in
+`antono2.vulkan.ergonomic` submodule adds typed errors, instance lifecycle
+helpers, and physical-device discovery without modifying generated files.
+See [the ergonomic API design](API_DESIGN.md).
+
 ## Generate
 The generator is located at [antono2/v_vulkan_bindings](https://github.com/antono2/v_vulkan_bindings)
 

--- a/ergonomic/ergonomic.v
+++ b/ergonomic/ergonomic.v
@@ -1,0 +1,116 @@
+module ergonomic
+
+import antono2.vulkan as vk
+
+// VulkanError preserves the VkResult and the operation which returned it.
+// Callers can match it with `if err is ergonomic.VulkanError`.
+pub struct VulkanError {
+	Error
+pub:
+	result    vk.Result
+	operation string
+}
+
+// msg implements IError without losing the original VkResult value.
+pub fn (err VulkanError) msg() string {
+	return '${err.operation}: ${err.result} (${int(err.result)})'
+}
+
+// is_error reports whether a VkResult is a Vulkan failure code. Positive
+// statuses such as timeout and incomplete are not failures.
+pub fn is_error(result vk.Result) bool {
+	return int(result) < 0
+}
+
+// check converts only Vulkan failure codes to typed V errors and
+// preserves success and positive status codes for the caller to inspect.
+pub fn check(result vk.Result, operation string) !vk.Result {
+	if is_error(result) {
+		return VulkanError{
+			result: result
+			operation: operation
+		}
+	}
+	return result
+}
+
+// require_success accepts only VK_SUCCESS. It is useful for operations whose
+// contract does not expose a meaningful positive status to the caller.
+pub fn require_success(result vk.Result, operation string) ! {
+	if result != .success {
+		return VulkanError{
+			result: result
+			operation: operation
+		}
+	}
+}
+
+// Instance is a lightweight wrapper around VkInstance. It does not destroy
+// itself implicitly; call destroy exactly once for every successfully created
+// instance.
+pub struct Instance {
+pub:
+	handle vk.Instance
+}
+
+// new_instance initializes Volk, creates an instance with Vulkan's default
+// allocator, and loads instance-level commands.
+pub fn new_instance(create_info &vk.InstanceCreateInfo) !Instance {
+	require_success(vk.initialize_loader(), 'volkInitialize')!
+	mut handle := vk.Instance(unsafe { nil })
+	require_success(vk.create_instance(create_info, unsafe { nil }, &handle), 'vkCreateInstance')!
+	vk.load_instance_commands(handle)
+	return Instance{
+		handle: handle
+	}
+}
+
+// destroy destroys an instance created by new_instance.
+pub fn (instance Instance) destroy() {
+	vk.destroy_instance(instance.handle, unsafe { nil })
+}
+
+// PhysicalDevice pairs a Vulkan handle with its core property snapshot.
+pub struct PhysicalDevice {
+pub:
+	handle     vk.PhysicalDevice
+	properties vk.PhysicalDeviceProperties
+}
+
+// name returns an owned V string copied from VkPhysicalDeviceProperties.
+pub fn (device PhysicalDevice) name() string {
+	return unsafe { cstring_to_vstring(&device.properties.deviceName[0]) }
+}
+
+// physical_devices performs Vulkan's count/fill enumeration pattern and
+// retries when the available device set changes and VK_INCOMPLETE is returned.
+pub fn (instance Instance) physical_devices() ![]PhysicalDevice {
+	for {
+		mut count := u32(0)
+		require_success(vk.enumerate_physical_devices(instance.handle, &count, unsafe {
+			nil
+		}), 'vkEnumeratePhysicalDevices(count)')!
+		if count == 0 {
+			return []PhysicalDevice{}
+		}
+
+		mut handles := unsafe { []vk.PhysicalDevice{len: int(count)} }
+		result := vk.enumerate_physical_devices(instance.handle, &count, handles.data)
+		if result == .incomplete {
+			continue
+		}
+		require_success(result, 'vkEnumeratePhysicalDevices(values)')!
+
+		mut devices := []PhysicalDevice{cap: int(count)}
+		for handle in handles[..int(count)] {
+			mut properties := vk.PhysicalDeviceProperties{}
+			vk.get_physical_device_properties(handle, mut properties)
+			devices << PhysicalDevice{
+				handle: handle
+				properties: properties
+			}
+		}
+		return devices
+	}
+	return []PhysicalDevice{}
+}

--- a/ergonomic/ergonomic_test.v
+++ b/ergonomic/ergonomic_test.v
@@ -1,0 +1,39 @@
+module ergonomic
+
+import antono2.vulkan as vk
+
+fn test_check_preserves_success_and_positive_statuses() ! {
+	assert check(.success, 'success')! == .success
+	assert check(.timeout, 'wait')! == .timeout
+	assert check(.incomplete, 'enumerate')! == .incomplete
+}
+
+fn test_check_returns_typed_vulkan_error() {
+	check(.error_device_lost, 'vkQueueSubmit') or {
+		assert err is VulkanError
+		if err is VulkanError {
+			assert err.result == vk.Result.error_device_lost
+			assert err.operation == 'vkQueueSubmit'
+			assert err.msg().contains('-4')
+		}
+		return
+	}
+	assert false
+}
+
+fn test_require_success_rejects_positive_status() {
+	require_success(.timeout, 'vkWaitForFences') or {
+		assert err is VulkanError
+		if err is VulkanError {
+			assert err.result == vk.Result.timeout
+		}
+		return
+	}
+	assert false
+}
+
+fn test_is_error_uses_vulkan_result_sign() {
+	assert !is_error(.success)
+	assert !is_error(.suboptimal_khr)
+	assert is_error(.error_out_of_date_khr)
+}


### PR DESCRIPTION
Add an opt-in antono2.vulkan.ergonomic submodule with typed Vulkan errors, loader-aware instance ownership, and resilient physical-device enumeration. Generated bindings remain unchanged. Includes API design conventions, documentation, unit tests, and CI coverage.