### PR TITLE
Add ergonomic Vulkan device API

### DIFF
--- a/API_DESIGN.md
+++ b/API_DESIGN.md
@@ -11,9 +11,9 @@ The generated `vulkan.v` and `vulkan_video.v` files remain the complete, low-lev
 - Two-call enumerations return V arrays and internally retry `VK_INCOMPLETE`.
 - Generated names and signatures are never edited to improve ergonomics. New wrappers compose them from the submodule.
 
-## First slice
+## Discovery and device slices
 
-The first slice covers loader initialization, default-allocator instance creation and destruction, physical-device enumeration, core property snapshots, and owned device-name strings:
+The first slice covers loader initialization, default-allocator instance creation and destruction, physical-device enumeration, core property snapshots, and owned device-name strings. The second slice adds queue-family discovery and selection by required `QueueFlags`, plus logical-device creation with one priority-1.0 queue:
 
 ```v
 import antono2.vulkan as vk
@@ -30,17 +30,24 @@ instance := vke.new_instance(&info)!
 defer {
 	instance.destroy()
 }
-for device in instance.physical_devices()! {
-	println('${device.name()} (${device.properties.vendorID:04x}:${device.properties.deviceID:04x})')
+physical_device := instance.physical_devices()![0]
+required := u32(vk.QueueFlagBits.graphics) | u32(vk.QueueFlagBits.compute)
+queue_family := physical_device.find_queue_family(required) or {
+	return error('no graphics/compute queue family')
 }
+device := physical_device.new_device(queue_family)!
+defer {
+	device.destroy()
+}
+println('${physical_device.name()}: queue family ${device.queue.family_index}')
 ```
 
-Custom allocation callbacks deliberately remain in the raw layer for now. A future owning wrapper must retain the allocator used at creation so the same callbacks are supplied during destruction.
+`Queue` is borrowed from its parent `Device` and becomes invalid when that device is destroyed. Custom allocation callbacks, queue priorities other than 1.0, enabled features, and device extensions deliberately remain in the raw layer for now. A future configurable owning wrapper must retain the allocator used at creation so the same callbacks are supplied during destruction.
 
 ## Next slices
 
 1. Instance extension and layer enumeration with owned V strings.
-2. Queue-family discovery and selection helpers that express required flags and presentation support.
-3. Logical-device creation with queue requests, extension validation, and instance/device dispatch loading.
+2. Presentation-support selection layered onto the core queue-flag helper.
+3. Configurable queue requests, extension validation, and enabled features.
 4. Owned buffers, images, command pools, and synchronization objects, each with explicit parent ownership and destruction ordering.
 5. Builders only where they eliminate unsafe pointer/count bookkeeping; Vulkan synchronization and memory choices should remain explicit.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Using GLFW and Dear ImGui [antono2/v_imgui_examples](https://github.com/antono2/
 
 The generated module remains the complete low-level binding. The opt-in
 `antono2.vulkan.ergonomic` submodule adds typed errors, instance lifecycle
-helpers, and physical-device discovery without modifying generated files.
+helpers, physical-device and queue-family discovery, and single-queue logical
+device ownership without modifying generated files.
 See [the ergonomic API design](API_DESIGN.md).
 
 ## Generate

--- a/ergonomic/ergonomic.v
+++ b/ergonomic/ergonomic.v
@@ -82,6 +82,116 @@ pub fn (device PhysicalDevice) name() string {
 	return unsafe { cstring_to_vstring(&device.properties.deviceName[0]) }
 }
 
+// QueueFamily pairs a queue-family index with its core property snapshot.
+pub struct QueueFamily {
+pub:
+	index      u32
+	properties vk.QueueFamilyProperties
+}
+
+// supports reports whether this family has at least one queue and includes all
+// required queue capability bits.
+pub fn (family QueueFamily) supports(required_flags vk.QueueFlags) bool {
+	return family.properties.queueCount > 0
+		&& family.properties.queueFlags & required_flags == required_flags
+}
+
+// select_queue_family returns the first queue family supporting every required
+// flag. An empty flag mask selects the first family with an available queue.
+pub fn select_queue_family(families []QueueFamily, required_flags vk.QueueFlags) ?QueueFamily {
+	for family in families {
+		if family.supports(required_flags) {
+			return family
+		}
+	}
+	return none
+}
+
+// queue_families returns owned snapshots of the physical device's core queue
+// family properties.
+pub fn (device PhysicalDevice) queue_families() []QueueFamily {
+	mut count := u32(0)
+	mut no_properties := unsafe { nil }
+	vk.get_physical_device_queue_family_properties(device.handle, &count, mut no_properties)
+	if count == 0 {
+		return []QueueFamily{}
+	}
+
+	mut properties := []vk.QueueFamilyProperties{len: int(count)}
+	vk.get_physical_device_queue_family_properties(device.handle, &count, mut properties[0])
+	mut families := []QueueFamily{cap: int(count)}
+	for index, property in properties[..int(count)] {
+		families << QueueFamily{
+			index: u32(index)
+			properties: property
+		}
+	}
+	return families
+}
+
+// find_queue_family discovers and selects the first family supporting every
+// required queue capability bit.
+pub fn (device PhysicalDevice) find_queue_family(required_flags vk.QueueFlags) ?QueueFamily {
+	return select_queue_family(device.queue_families(), required_flags)
+}
+
+// Queue is a borrowed queue handle owned by its parent Device.
+pub struct Queue {
+pub:
+	handle       vk.Queue
+	family_index u32
+	index        u32
+}
+
+// Device owns a logical VkDevice and exposes its single requested queue. It
+// does not destroy itself implicitly; call destroy exactly once.
+pub struct Device {
+pub:
+	handle vk.Device
+	queue  Queue
+}
+
+// new_device creates a logical device with one queue at priority 1.0 from the
+// selected family, then loads Volk's device-level commands.
+//
+// queue_family must have been discovered from this PhysicalDevice.
+pub fn (physical_device PhysicalDevice) new_device(queue_family QueueFamily) !Device {
+	if queue_family.properties.queueCount == 0 {
+		return error('queue family ${queue_family.index} has no queues')
+	}
+
+	mut priority := f32(1.0)
+	queue_info := vk.DeviceQueueCreateInfo{
+		queueFamilyIndex: queue_family.index
+		queueCount: 1
+		pQueuePriorities: &priority
+	}
+	create_info := vk.DeviceCreateInfo{
+		queueCreateInfoCount: 1
+		pQueueCreateInfos: &queue_info
+	}
+	mut handle := vk.Device(unsafe { nil })
+	require_success(vk.create_device(physical_device.handle, &create_info, unsafe { nil }, &handle), 'vkCreateDevice')!
+	vk.load_device_commands(handle)
+
+	mut queue_handle := vk.Queue(unsafe { nil })
+	vk.get_device_queue(handle, queue_family.index, 0, &queue_handle)
+	return Device{
+		handle: handle
+		queue: Queue{
+			handle: queue_handle
+			family_index: queue_family.index
+			index: 0
+		}
+	}
+}
+
+// destroy destroys a logical device created by new_device. Its queue handle
+// becomes invalid at the same time.
+pub fn (device Device) destroy() {
+	vk.destroy_device(device.handle, unsafe { nil })
+}
+
 // physical_devices performs Vulkan's count/fill enumeration pattern and
 // retries when the available device set changes and VK_INCOMPLETE is returned.
 pub fn (instance Instance) physical_devices() ![]PhysicalDevice {

--- a/ergonomic/ergonomic_test.v
+++ b/ergonomic/ergonomic_test.v
@@ -37,3 +37,57 @@ fn test_is_error_uses_vulkan_result_sign() {
 	assert !is_error(.suboptimal_khr)
 	assert is_error(.error_out_of_date_khr)
 }
+
+fn queue_family(index u32, flags vk.QueueFlags, count u32) QueueFamily {
+	return QueueFamily{
+		index: index
+		properties: vk.QueueFamilyProperties{
+			queueFlags: flags
+			queueCount: count
+		}
+	}
+}
+
+fn test_queue_family_supports_all_required_flags() {
+	graphics_compute := u32(vk.QueueFlagBits.graphics) | u32(vk.QueueFlagBits.compute)
+	family := queue_family(3, graphics_compute, 2)
+	assert family.supports(u32(vk.QueueFlagBits.graphics))
+	assert family.supports(graphics_compute)
+	assert !family.supports(graphics_compute | u32(vk.QueueFlagBits.transfer))
+}
+
+fn test_queue_family_with_no_queues_is_not_supported() {
+	family := queue_family(0, u32(vk.QueueFlagBits.graphics), 0)
+	assert !family.supports(u32(vk.QueueFlagBits.graphics))
+	assert !family.supports(0)
+}
+
+fn test_select_queue_family_returns_first_full_match() {
+	families := [
+		queue_family(0, u32(vk.QueueFlagBits.graphics), 1),
+		queue_family(1, u32(vk.QueueFlagBits.compute) | u32(vk.QueueFlagBits.transfer), 1),
+		queue_family(2, u32(vk.QueueFlagBits.compute) | u32(vk.QueueFlagBits.transfer), 2),
+	]
+	required := u32(vk.QueueFlagBits.compute) | u32(vk.QueueFlagBits.transfer)
+	selected := select_queue_family(families, required) or {
+		assert false
+		return
+	}
+	assert selected.index == 1
+	assert selected.properties.queueCount == 1
+}
+
+fn test_select_queue_family_returns_none_without_a_match() {
+	families := [queue_family(0, u32(vk.QueueFlagBits.graphics), 1)]
+	select_queue_family(families, u32(vk.QueueFlagBits.compute)) or { return }
+	assert false
+}
+
+fn test_empty_flag_mask_selects_first_available_queue() {
+	families := [queue_family(0, 0, 0), queue_family(1, 0, 1)]
+	selected := select_queue_family(families, 0) or {
+		assert false
+		return
+	}
+	assert selected.index == 1
+}


### PR DESCRIPTION
## Summary
- discover queue families and select the first family containing every required QueueFlags bit
- create a logical device with one priority-1.0 queue, load Volk device commands, and expose raw Device and Queue handles
- document explicit device/queue lifetime rules and add pure queue-selection tests

## Verification
- `v fmt -verify ergonomic/ergonomic.v ergonomic/ergonomic_test.v`
- `v -check-syntax ergonomic/ergonomic.v`
- `v -check-syntax ergonomic/ergonomic_test.v`
- `git diff --check`

Full binding compilation is delegated to GitHub Actions per repository guidance.