### PR TITLE
Add owned Vulkan buffer API

### DIFF
--- a/API_DESIGN.md
+++ b/API_DESIGN.md
@@ -11,9 +11,9 @@ The generated `vulkan.v` and `vulkan_video.v` files remain the complete, low-lev
 - Two-call enumerations return V arrays and internally retry `VK_INCOMPLETE`.
 - Generated names and signatures are never edited to improve ergonomics. New wrappers compose them from the submodule.
 
-## Discovery and device slices
+## Discovery, device, and buffer slices
 
-The first slice covers loader initialization, default-allocator instance creation and destruction, physical-device enumeration, core property snapshots, and owned device-name strings. The second slice adds queue-family discovery and selection by required `QueueFlags`, plus logical-device creation with one priority-1.0 queue:
+The first slice covers loader initialization, default-allocator instance creation and destruction, physical-device enumeration, core property snapshots, and owned device-name strings. The second slice adds queue-family discovery and selection by required `QueueFlags`, plus logical-device creation with one priority-1.0 queue. The third slice adds memory-type selection and buffers which own their bound device-memory allocation:
 
 ```v
 import antono2.vulkan as vk
@@ -39,15 +39,23 @@ device := physical_device.new_device(queue_family)!
 defer {
 	device.destroy()
 }
+usage := u32(vk.BufferUsageFlagBits.vertex_buffer) | u32(vk.BufferUsageFlagBits.transfer_dst)
+memory_properties := u32(vk.MemoryPropertyFlagBits.device_local)
+buffer := device.new_buffer(4096, usage, memory_properties)!
+defer {
+	buffer.destroy()
+}
 println('${physical_device.name()}: queue family ${device.queue.family_index}')
 ```
 
-`Queue` is borrowed from its parent `Device` and becomes invalid when that device is destroyed. Custom allocation callbacks, queue priorities other than 1.0, enabled features, and device extensions deliberately remain in the raw layer for now. A future configurable owning wrapper must retain the allocator used at creation so the same callbacks are supplied during destruction.
+`Queue` is borrowed from its parent `Device` and becomes invalid when that device is destroyed. `OwnedBuffer` exposes its raw buffer and memory handles, requested size, allocation size, and selected memory-type index. Its `destroy()` method always destroys the buffer before freeing its memory; callers must destroy every buffer before destroying the parent device. `PhysicalDevice.find_memory_type()` applies both the resource's allowed-memory-type bit mask and the complete required property mask.
+
+Custom allocation callbacks, concurrent-sharing buffers, queue priorities other than 1.0, enabled features, and device extensions deliberately remain in the raw layer for now. A future configurable owning wrapper must retain the allocator used at creation so the same callbacks are supplied during destruction.
 
 ## Next slices
 
 1. Instance extension and layer enumeration with owned V strings.
 2. Presentation-support selection layered onto the core queue-flag helper.
 3. Configurable queue requests, extension validation, and enabled features.
-4. Owned buffers, images, command pools, and synchronization objects, each with explicit parent ownership and destruction ordering.
+4. Owned images, command pools, and synchronization objects, each with explicit parent ownership and destruction ordering.
 5. Builders only where they eliminate unsafe pointer/count bookkeeping; Vulkan synchronization and memory choices should remain explicit.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Using GLFW and Dear ImGui [antono2/v_imgui_examples](https://github.com/antono2/
 The generated module remains the complete low-level binding. The opt-in
 `antono2.vulkan.ergonomic` submodule adds typed errors, instance lifecycle
 helpers, physical-device and queue-family discovery, and single-queue logical
-device ownership without modifying generated files.
+device ownership. It also provides explicit memory-type selection and owned
+buffer/device-memory allocation without modifying generated files.
 See [the ergonomic API design](API_DESIGN.md).
 
 ## Generate

--- a/ergonomic/ergonomic.v
+++ b/ergonomic/ergonomic.v
@@ -82,6 +82,34 @@ pub fn (device PhysicalDevice) name() string {
 	return unsafe { cstring_to_vstring(&device.properties.deviceName[0]) }
 }
 
+// memory_properties returns an owned snapshot of the physical device's core
+// memory heaps and types.
+pub fn (device PhysicalDevice) memory_properties() vk.PhysicalDeviceMemoryProperties {
+	mut properties := vk.PhysicalDeviceMemoryProperties{}
+	vk.get_physical_device_memory_properties(device.handle, mut properties)
+	return properties
+}
+
+// select_memory_type returns the first memory type which is both present in
+// allowed_type_bits and contains every required property flag.
+pub fn select_memory_type(properties vk.PhysicalDeviceMemoryProperties, allowed_type_bits u32, required_properties vk.MemoryPropertyFlags) ?u32 {
+	for index in 0 .. int(properties.memoryTypeCount) {
+		allowed := allowed_type_bits & (u32(1) << u32(index)) != 0
+		flags := properties.memoryTypes[index].propertyFlags
+		if allowed && flags & required_properties == required_properties {
+			return u32(index)
+		}
+	}
+	return none
+}
+
+// find_memory_type queries the physical device and returns the first memory
+// type allowed by a resource's memoryTypeBits which contains every required
+// property flag.
+pub fn (device PhysicalDevice) find_memory_type(allowed_type_bits u32, required_properties vk.MemoryPropertyFlags) ?u32 {
+	return select_memory_type(device.memory_properties(), allowed_type_bits, required_properties)
+}
+
 // QueueFamily pairs a queue-family index with its core property snapshot.
 pub struct QueueFamily {
 pub:
@@ -146,6 +174,7 @@ pub:
 // Device owns a logical VkDevice and exposes its single requested queue. It
 // does not destroy itself implicitly; call destroy exactly once.
 pub struct Device {
+	physical_device PhysicalDevice
 pub:
 	handle vk.Device
 	queue  Queue
@@ -177,6 +206,7 @@ pub fn (physical_device PhysicalDevice) new_device(queue_family QueueFamily) !De
 	mut queue_handle := vk.Queue(unsafe { nil })
 	vk.get_device_queue(handle, queue_family.index, 0, &queue_handle)
 	return Device{
+		physical_device: physical_device
 		handle: handle
 		queue: Queue{
 			handle: queue_handle
@@ -190,6 +220,75 @@ pub fn (physical_device PhysicalDevice) new_device(queue_family QueueFamily) !De
 // becomes invalid at the same time.
 pub fn (device Device) destroy() {
 	vk.destroy_device(device.handle, unsafe { nil })
+}
+
+// OwnedBuffer owns a VkBuffer and its bound VkDeviceMemory allocation. Both
+// raw handles remain public for commands and interoperability. Destroy the
+// buffer before destroying its parent Device.
+pub struct OwnedBuffer {
+	device vk.Device
+pub:
+	handle            vk.Buffer
+	memory            vk.DeviceMemory
+	size              vk.DeviceSize
+	allocation_size   vk.DeviceSize
+	memory_type_index u32
+}
+
+// new_buffer creates an exclusive-sharing buffer, selects a compatible memory
+// type containing every required property, allocates memory, and binds it at
+// offset zero.
+pub fn (device Device) new_buffer(size vk.DeviceSize, usage vk.BufferUsageFlags, required_memory_properties vk.MemoryPropertyFlags) !OwnedBuffer {
+	if size == 0 {
+		return error('buffer size must be greater than zero')
+	}
+
+	create_info := vk.BufferCreateInfo{
+		size: size
+		usage: usage
+		sharingMode: .exclusive
+	}
+	mut handle := vk.Buffer(unsafe { nil })
+	require_success(vk.create_buffer(device.handle, &create_info, unsafe { nil }, &handle), 'vkCreateBuffer')!
+
+	mut requirements := vk.MemoryRequirements{}
+	vk.get_buffer_memory_requirements(device.handle, handle, mut requirements)
+	memory_type_index := device.physical_device.find_memory_type(requirements.memoryTypeBits, required_memory_properties) or {
+		vk.destroy_buffer(device.handle, handle, unsafe { nil })
+		return error('no compatible memory type for buffer')
+	}
+
+	allocate_info := vk.MemoryAllocateInfo{
+		allocationSize: requirements.size
+		memoryTypeIndex: memory_type_index
+	}
+	mut memory := vk.DeviceMemory(unsafe { nil })
+	require_success(vk.allocate_memory(device.handle, &allocate_info, unsafe { nil }, &memory), 'vkAllocateMemory') or {
+		vk.destroy_buffer(device.handle, handle, unsafe { nil })
+		return err
+	}
+
+	require_success(vk.bind_buffer_memory(device.handle, handle, memory, 0), 'vkBindBufferMemory') or {
+		vk.destroy_buffer(device.handle, handle, unsafe { nil })
+		vk.free_memory(device.handle, memory, unsafe { nil })
+		return err
+	}
+
+	return OwnedBuffer{
+		device: device.handle
+		handle: handle
+		memory: memory
+		size: size
+		allocation_size: requirements.size
+		memory_type_index: memory_type_index
+	}
+}
+
+// destroy first destroys the buffer, then frees its bound memory. Call it
+// exactly once for every successfully created OwnedBuffer.
+pub fn (buffer OwnedBuffer) destroy() {
+	vk.destroy_buffer(buffer.device, buffer.handle, unsafe { nil })
+	vk.free_memory(buffer.device, buffer.memory, unsafe { nil })
 }
 
 // physical_devices performs Vulkan's count/fill enumeration pattern and

--- a/ergonomic/ergonomic_test.v
+++ b/ergonomic/ergonomic_test.v
@@ -91,3 +91,50 @@ fn test_empty_flag_mask_selects_first_available_queue() {
 	}
 	assert selected.index == 1
 }
+
+fn memory_properties(types []vk.MemoryPropertyFlags) vk.PhysicalDeviceMemoryProperties {
+	mut properties := vk.PhysicalDeviceMemoryProperties{
+		memoryTypeCount: u32(types.len)
+	}
+	for index, flags in types {
+		properties.memoryTypes[index] = vk.MemoryType{
+			propertyFlags: flags
+		}
+	}
+	return properties
+}
+
+fn test_select_memory_type_requires_allowed_bit_and_all_properties() {
+	host_visible := u32(vk.MemoryPropertyFlagBits.host_visible)
+	host_coherent := u32(vk.MemoryPropertyFlagBits.host_coherent)
+	properties := memory_properties([
+		host_visible,
+		host_coherent,
+		host_visible | host_coherent,
+	])
+
+	selected := select_memory_type(properties, u32(0b110), host_visible | host_coherent) or {
+		assert false
+		return
+	}
+	assert selected == 2
+}
+
+fn test_select_memory_type_returns_none_without_compatible_type() {
+	properties := memory_properties([
+		u32(vk.MemoryPropertyFlagBits.device_local),
+		u32(vk.MemoryPropertyFlagBits.host_visible),
+	])
+	required := u32(vk.MemoryPropertyFlagBits.host_visible) | u32(vk.MemoryPropertyFlagBits.host_coherent)
+
+	select_memory_type(properties, u32(0b11), required) or { return }
+	assert false
+}
+
+fn test_select_memory_type_ignores_compatible_disallowed_type() {
+	host_visible := u32(vk.MemoryPropertyFlagBits.host_visible)
+	properties := memory_properties([host_visible, 0])
+
+	select_memory_type(properties, u32(0b10), host_visible) or { return }
+	assert false
+}


### PR DESCRIPTION
## Summary
- add physical-device memory property snapshots and compatible memory-type selection
- add an owned buffer/device-memory composite with explicit property requirements and safe cleanup order
- document buffer lifetime rules and cover memory selection edge cases

## Validation
- `v fmt -verify ergonomic/ergonomic.v ergonomic/ergonomic_test.v`
- `v -check-syntax ergonomic/ergonomic.v`
- `v -check-syntax ergonomic/ergonomic_test.v`
- full compilation delegated to GitHub Actions per repository guidance