### PR TITLE
Add owned Vulkan command API

### DIFF
--- a/API_DESIGN.md
+++ b/API_DESIGN.md
@@ -50,7 +50,7 @@ pool := device.new_command_pool(pool_flags)!
 defer {
 	pool.destroy()
 }
-command_buffer := pool.allocate_primary(1)![0]
+mut command_buffer := pool.allocate_primary(1)![0]
 defer {
 	command_buffer.free()
 }
@@ -62,7 +62,7 @@ println('${physical_device.name()}: queue family ${device.queue.family_index}')
 
 `Queue` is borrowed from its parent `Device` and becomes invalid when that device is destroyed. `OwnedBuffer` exposes its raw buffer and memory handles, requested size, allocation size, and selected memory-type index. Its `destroy()` method always destroys the buffer before freeing its memory; callers must destroy every buffer before destroying the parent device. `PhysicalDevice.find_memory_type()` applies both the resource's allowed-memory-type bit mask and the complete required property mask.
 
-`CommandPool` belongs to its parent `Device` and is fixed to that device's selected queue-family index. `PrimaryCommandBuffer` retains the exact device and pool handles needed by `free()`, while its public raw `handle` remains available for recording and submission. Reset, begin, and end failures are returned as typed `VulkanError` values. Destroying a command pool implicitly frees and invalidates all command buffers still allocated from it; callers may either free buffers explicitly before pool destruction or rely on that Vulkan lifetime rule, but must never use or free a buffer after its pool is destroyed. Every command pool must be destroyed before its parent device.
+`CommandPool` belongs to its parent `Device` and is fixed to that device's selected queue-family index. `PrimaryCommandBuffer` retains the exact device and pool handles needed by `free()`, while its public raw `handle` remains available for recording and submission. `free()` is idempotent and clears that raw handle. Reset, begin, and end failures are returned as typed `VulkanError` values. Destroying a command pool implicitly frees and invalidates all command buffers still allocated from it; callers may either free buffers explicitly before pool destruction or rely on that Vulkan lifetime rule, but must never use or free a buffer after its pool is destroyed. Every command pool must be destroyed before its parent device.
 
 Custom allocation callbacks, concurrent-sharing buffers, queue priorities other than 1.0, enabled features, and device extensions deliberately remain in the raw layer for now. A future configurable owning wrapper must retain the allocator used at creation so the same callbacks are supplied during destruction.
 

--- a/API_DESIGN.md
+++ b/API_DESIGN.md
@@ -11,9 +11,9 @@ The generated `vulkan.v` and `vulkan_video.v` files remain the complete, low-lev
 - Two-call enumerations return V arrays and internally retry `VK_INCOMPLETE`.
 - Generated names and signatures are never edited to improve ergonomics. New wrappers compose them from the submodule.
 
-## Discovery, device, and buffer slices
+## Discovery, device, buffer, and command slices
 
-The first slice covers loader initialization, default-allocator instance creation and destruction, physical-device enumeration, core property snapshots, and owned device-name strings. The second slice adds queue-family discovery and selection by required `QueueFlags`, plus logical-device creation with one priority-1.0 queue. The third slice adds memory-type selection and buffers which own their bound device-memory allocation:
+The first slice covers loader initialization, default-allocator instance creation and destruction, physical-device enumeration, core property snapshots, and owned device-name strings. The second slice adds queue-family discovery and selection by required `QueueFlags`, plus logical-device creation with one priority-1.0 queue. The third slice adds memory-type selection and buffers which own their bound device-memory allocation. The fourth slice adds owned command pools and primary command buffers:
 
 ```v
 import antono2.vulkan as vk
@@ -45,10 +45,24 @@ buffer := device.new_buffer(4096, usage, memory_properties)!
 defer {
 	buffer.destroy()
 }
+pool_flags := u32(vk.CommandPoolCreateFlagBits.reset_command_buffer)
+pool := device.new_command_pool(pool_flags)!
+defer {
+	pool.destroy()
+}
+command_buffer := pool.allocate_primary(1)![0]
+defer {
+	command_buffer.free()
+}
+command_buffer.begin(u32(vk.CommandBufferUsageFlagBits.one_time_submit))!
+// Record commands with command_buffer.handle.
+command_buffer.end()!
 println('${physical_device.name()}: queue family ${device.queue.family_index}')
 ```
 
 `Queue` is borrowed from its parent `Device` and becomes invalid when that device is destroyed. `OwnedBuffer` exposes its raw buffer and memory handles, requested size, allocation size, and selected memory-type index. Its `destroy()` method always destroys the buffer before freeing its memory; callers must destroy every buffer before destroying the parent device. `PhysicalDevice.find_memory_type()` applies both the resource's allowed-memory-type bit mask and the complete required property mask.
+
+`CommandPool` belongs to its parent `Device` and is fixed to that device's selected queue-family index. `PrimaryCommandBuffer` retains the exact device and pool handles needed by `free()`, while its public raw `handle` remains available for recording and submission. Reset, begin, and end failures are returned as typed `VulkanError` values. Destroying a command pool implicitly frees and invalidates all command buffers still allocated from it; callers may either free buffers explicitly before pool destruction or rely on that Vulkan lifetime rule, but must never use or free a buffer after its pool is destroyed. Every command pool must be destroyed before its parent device.
 
 Custom allocation callbacks, concurrent-sharing buffers, queue priorities other than 1.0, enabled features, and device extensions deliberately remain in the raw layer for now. A future configurable owning wrapper must retain the allocator used at creation so the same callbacks are supplied during destruction.
 
@@ -57,5 +71,5 @@ Custom allocation callbacks, concurrent-sharing buffers, queue priorities other 
 1. Instance extension and layer enumeration with owned V strings.
 2. Presentation-support selection layered onto the core queue-flag helper.
 3. Configurable queue requests, extension validation, and enabled features.
-4. Owned images, command pools, and synchronization objects, each with explicit parent ownership and destruction ordering.
+4. Owned images and synchronization objects, each with explicit parent ownership and destruction ordering.
 5. Builders only where they eliminate unsafe pointer/count bookkeeping; Vulkan synchronization and memory choices should remain explicit.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ The generated module remains the complete low-level binding. The opt-in
 `antono2.vulkan.ergonomic` submodule adds typed errors, instance lifecycle
 helpers, physical-device and queue-family discovery, and single-queue logical
 device ownership. It also provides explicit memory-type selection and owned
-buffer/device-memory allocation without modifying generated files.
+buffer/device-memory allocation, plus owned command pools and primary command
+buffer lifecycle helpers, without modifying generated files.
 See [the ergonomic API design](API_DESIGN.md).
 
 ## Generate

--- a/ergonomic/ergonomic.v
+++ b/ergonomic/ergonomic.v
@@ -222,6 +222,106 @@ pub fn (device Device) destroy() {
 	vk.destroy_device(device.handle, unsafe { nil })
 }
 
+// CommandPool owns a VkCommandPool for the queue family requested when its
+// parent Device was created. The parent Device must outlive the pool.
+pub struct CommandPool {
+	device vk.Device
+pub:
+	handle             vk.CommandPool
+	queue_family_index u32
+	flags              vk.CommandPoolCreateFlags
+}
+
+// new_command_pool creates a command pool for the Device's queue family with
+// Vulkan's default allocator.
+pub fn (device Device) new_command_pool(flags vk.CommandPoolCreateFlags) !CommandPool {
+	create_info := vk.CommandPoolCreateInfo{
+		flags: flags
+		queueFamilyIndex: device.queue.family_index
+	}
+	mut handle := vk.CommandPool(unsafe { nil })
+	require_success(vk.create_command_pool(device.handle, &create_info, unsafe { nil }, &handle), 'vkCreateCommandPool')!
+	return CommandPool{
+		device: device.handle
+		handle: handle
+		queue_family_index: device.queue.family_index
+		flags: flags
+	}
+}
+
+// reset resets the pool and every command buffer allocated from it.
+pub fn (pool CommandPool) reset(flags vk.CommandPoolResetFlags) ! {
+	require_success(vk.reset_command_pool(pool.device, pool.handle, flags), 'vkResetCommandPool')!
+}
+
+// PrimaryCommandBuffer is allocated from one CommandPool and retains the exact
+// device and pool handles required to free it. Its raw handle remains public
+// for recording and submission commands.
+pub struct PrimaryCommandBuffer {
+	device       vk.Device
+	command_pool vk.CommandPool
+pub:
+	handle vk.CommandBuffer
+}
+
+// allocate_primary allocates count primary command buffers from the pool.
+pub fn (pool CommandPool) allocate_primary(count u32) ![]PrimaryCommandBuffer {
+	if count == 0 {
+		return error('command buffer count must be greater than zero')
+	}
+
+	allocate_info := vk.CommandBufferAllocateInfo{
+		commandPool: pool.handle
+		level: .primary
+		commandBufferCount: count
+	}
+	mut handles := unsafe { []vk.CommandBuffer{len: int(count)} }
+	require_success(vk.allocate_command_buffers(pool.device, &allocate_info, handles.data), 'vkAllocateCommandBuffers')!
+
+	mut buffers := []PrimaryCommandBuffer{cap: int(count)}
+	for handle in handles {
+		buffers << PrimaryCommandBuffer{
+			device: pool.device
+			command_pool: pool.handle
+			handle: handle
+		}
+	}
+	return buffers
+}
+
+// free returns this command buffer to the pool which allocated it. Call it at
+// most once, and never after destroying its parent pool.
+pub fn (buffer PrimaryCommandBuffer) free() {
+	vk.free_command_buffers(buffer.device, buffer.command_pool, 1, &buffer.handle)
+}
+
+// reset returns this command buffer to its initial state. Its pool must have
+// been created with VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT.
+pub fn (buffer PrimaryCommandBuffer) reset(flags vk.CommandBufferResetFlags) ! {
+	require_success(vk.reset_command_buffer(buffer.handle, flags), 'vkResetCommandBuffer')!
+}
+
+// begin starts recording this primary command buffer. Inheritance information
+// is intentionally null because it is only meaningful for secondary buffers.
+pub fn (buffer PrimaryCommandBuffer) begin(flags vk.CommandBufferUsageFlags) ! {
+	begin_info := vk.CommandBufferBeginInfo{
+		flags: flags
+		pInheritanceInfo: unsafe { nil }
+	}
+	require_success(vk.begin_command_buffer(buffer.handle, &begin_info), 'vkBeginCommandBuffer')!
+}
+
+// end finishes recording this command buffer.
+pub fn (buffer PrimaryCommandBuffer) end() ! {
+	require_success(vk.end_command_buffer(buffer.handle), 'vkEndCommandBuffer')!
+}
+
+// destroy destroys the command pool and implicitly frees every command buffer
+// still allocated from it. Those wrappers must not be used afterwards.
+pub fn (pool CommandPool) destroy() {
+	vk.destroy_command_pool(pool.device, pool.handle, unsafe { nil })
+}
+
 // OwnedBuffer owns a VkBuffer and its bound VkDeviceMemory allocation. Both
 // raw handles remain public for commands and interoperability. Destroy the
 // buffer before destroying its parent Device.

--- a/ergonomic/ergonomic.v
+++ b/ergonomic/ergonomic.v
@@ -260,7 +260,7 @@ pub fn (pool CommandPool) reset(flags vk.CommandPoolResetFlags) ! {
 pub struct PrimaryCommandBuffer {
 	device       vk.Device
 	command_pool vk.CommandPool
-pub:
+pub mut:
 	handle vk.CommandBuffer
 }
 

--- a/ergonomic/ergonomic.v
+++ b/ergonomic/ergonomic.v
@@ -291,7 +291,7 @@ pub fn (pool CommandPool) allocate_primary(count u32) ![]PrimaryCommandBuffer {
 
 // free returns this command buffer to the pool which allocated it. Call it at
 // most once, and never after destroying its parent pool.
-pub fn (buffer PrimaryCommandBuffer) free() {
+pub fn (buffer &PrimaryCommandBuffer) free() {
 	vk.free_command_buffers(buffer.device, buffer.command_pool, 1, &buffer.handle)
 }
 

--- a/ergonomic/ergonomic.v
+++ b/ergonomic/ergonomic.v
@@ -289,10 +289,15 @@ pub fn (pool CommandPool) allocate_primary(count u32) ![]PrimaryCommandBuffer {
 	return buffers
 }
 
-// free returns this command buffer to the pool which allocated it. Call it at
-// most once, and never after destroying its parent pool.
-pub fn (buffer &PrimaryCommandBuffer) free() {
+// free returns this command buffer to the pool which allocated it and clears
+// its handle. Repeated calls are harmless, but it must not be called after
+// destroying the parent pool.
+pub fn (mut buffer PrimaryCommandBuffer) free() {
+	if isnil(buffer.handle) {
+		return
+	}
 	vk.free_command_buffers(buffer.device, buffer.command_pool, 1, &buffer.handle)
+	buffer.handle = vk.CommandBuffer(unsafe { nil })
 }
 
 // reset returns this command buffer to its initial state. Its pool must have

--- a/ergonomic/ergonomic_test.v
+++ b/ergonomic/ergonomic_test.v
@@ -127,6 +127,17 @@ fn test_allocate_primary_rejects_zero_count_before_calling_vulkan() {
 	assert false
 }
 
+fn test_free_is_idempotent_for_an_already_cleared_command_buffer() {
+	mut buffer := PrimaryCommandBuffer{
+		device: vk.Device(unsafe { nil })
+		command_pool: vk.CommandPool(unsafe { nil })
+		handle: vk.CommandBuffer(unsafe { nil })
+	}
+	buffer.free()
+	buffer.free()
+	assert isnil(buffer.handle)
+}
+
 fn memory_properties(types []vk.MemoryPropertyFlags) vk.PhysicalDeviceMemoryProperties {
 	mut properties := vk.PhysicalDeviceMemoryProperties{
 		memoryTypeCount: u32(types.len)

--- a/ergonomic/ergonomic_test.v
+++ b/ergonomic/ergonomic_test.v
@@ -92,6 +92,41 @@ fn test_empty_flag_mask_selects_first_available_queue() {
 	assert selected.index == 1
 }
 
+fn test_command_pool_and_primary_buffer_expose_raw_handles_and_ownership_metadata() {
+	pool_handle := vk.CommandPool(unsafe { nil })
+	buffer_handle := vk.CommandBuffer(unsafe { nil })
+	flags := u32(vk.CommandPoolCreateFlagBits.reset_command_buffer)
+	pool := CommandPool{
+		device: vk.Device(unsafe { nil })
+		handle: pool_handle
+		queue_family_index: 4
+		flags: flags
+	}
+	buffer := PrimaryCommandBuffer{
+		device: vk.Device(unsafe { nil })
+		command_pool: pool.handle
+		handle: buffer_handle
+	}
+
+	assert pool.handle == pool_handle
+	assert pool.queue_family_index == 4
+	assert pool.flags == flags
+	assert buffer.handle == buffer_handle
+	assert buffer.command_pool == pool.handle
+}
+
+fn test_allocate_primary_rejects_zero_count_before_calling_vulkan() {
+	pool := CommandPool{
+		device: vk.Device(unsafe { nil })
+		handle: vk.CommandPool(unsafe { nil })
+	}
+	pool.allocate_primary(0) or {
+		assert err.msg() == 'command buffer count must be greater than zero'
+		return
+	}
+	assert false
+}
+
 fn memory_properties(types []vk.MemoryPropertyFlags) vk.PhysicalDeviceMemoryProperties {
 	mut properties := vk.PhysicalDeviceMemoryProperties{
 		memoryTypeCount: u32(types.len)


### PR DESCRIPTION
## Summary
- add owned command pools tied to the logical device queue family
- add primary command-buffer allocation, explicit free/reset/begin/end helpers, and raw handles
- document pool/device lifetime rules and extend ergonomic API tests

## Local checks
- `v fmt -verify ergonomic/ergonomic.v ergonomic/ergonomic_test.v`
- `v -check-syntax ergonomic`
- `git diff --check`

Full compilation is delegated to GitHub Actions.