### PR TITLE
Add owned Vulkan 2D images

### DIFF
--- a/API_DESIGN.md
+++ b/API_DESIGN.md
@@ -75,6 +75,8 @@ println('${physical_device.name()}: queue family ${device.queue.family_index}')
 
 `Fence` exposes status, timeout-aware waiting, and reset while preserving positive Vulkan statuses such as `VK_NOT_READY` and `VK_TIMEOUT`. `Fence` and `Semaphore` expose their raw handles for submission structures, clear those handles during idempotent destruction, and must be destroyed before their parent device.
 
+`OwnedImage` creates a simple exclusive-sharing 2D image with one mip level, one array layer, and one sample. It exposes the raw image and memory handles plus its format, extent, tiling, usage, allocation size, and selected memory type. Destruction releases the image before its bound allocation, and must happen before destroying the parent device. More specialized image creation remains available through the raw layer.
+
 Custom allocation callbacks, concurrent-sharing buffers, queue priorities other than 1.0, enabled features, and device extensions deliberately remain in the raw layer for now. A future configurable owning wrapper must retain the allocator used at creation so the same callbacks are supplied during destruction.
 
 ## Next slices
@@ -83,5 +85,5 @@ Custom allocation callbacks, concurrent-sharing buffers, queue priorities other 
 2. Presentation-support selection layered onto the core queue-flag helper.
 3. Configurable queue requests, extension validation, and enabled features.
 4. Owned fences and binary semaphores with explicit parent ownership and destruction ordering. (Implemented.)
-5. Owned images with explicit parent ownership and destruction ordering.
+5. Owned 2D images with explicit parent ownership and destruction ordering. (Implemented.)
 6. Builders only where they eliminate unsafe pointer/count bookkeeping; Vulkan synchronization and memory choices should remain explicit.

--- a/ergonomic/ergonomic.v
+++ b/ergonomic/ergonomic.v
@@ -396,6 +396,92 @@ pub fn (buffer OwnedBuffer) destroy() {
 	vk.free_memory(buffer.device, buffer.memory, unsafe { nil })
 }
 
+// OwnedImage owns a two-dimensional VkImage and its bound VkDeviceMemory.
+// The image uses one mip level, one array layer, and one sample.
+pub struct OwnedImage {
+	device vk.Device
+pub:
+	handle            vk.Image
+	memory            vk.DeviceMemory
+	format            vk.Format
+	extent            vk.Extent3D
+	tiling            vk.ImageTiling
+	usage             vk.ImageUsageFlags
+	allocation_size   vk.DeviceSize
+	memory_type_index u32
+}
+
+// new_image_2d creates an exclusive-sharing 2D image, chooses memory satisfying
+// all required properties, allocates it, and binds it at offset zero.
+pub fn (device Device) new_image_2d(width u32, height u32, format vk.Format, tiling vk.ImageTiling,
+	usage vk.ImageUsageFlags, required_memory_properties vk.MemoryPropertyFlags) !OwnedImage {
+	if width == 0 || height == 0 {
+		return error('image width and height must be greater than zero')
+	}
+	if usage == 0 {
+		return error('image usage must not be empty')
+	}
+	extent := vk.Extent3D{
+		width: width
+		height: height
+		depth: 1
+	}
+	create_info := vk.ImageCreateInfo{
+		imageType: ._2d
+		format: format
+		extent: extent
+		mipLevels: 1
+		arrayLayers: 1
+		samples: ._1
+		tiling: tiling
+		usage: usage
+		sharingMode: .exclusive
+		initialLayout: .undefined
+	}
+	mut handle := vk.Image(unsafe { nil })
+	require_success(vk.create_image(device.handle, &create_info, unsafe { nil }, &handle), 'vkCreateImage')!
+
+	mut requirements := vk.MemoryRequirements{}
+	vk.get_image_memory_requirements(device.handle, handle, mut requirements)
+	memory_type_index := device.physical_device.find_memory_type(requirements.memoryTypeBits, required_memory_properties) or {
+		vk.destroy_image(device.handle, handle, unsafe { nil })
+		return error('no compatible memory type for image')
+	}
+	allocate_info := vk.MemoryAllocateInfo{
+		allocationSize: requirements.size
+		memoryTypeIndex: memory_type_index
+	}
+	mut memory := vk.DeviceMemory(unsafe { nil })
+	require_success(vk.allocate_memory(device.handle, &allocate_info, unsafe { nil }, &memory), 'vkAllocateMemory') or {
+		vk.destroy_image(device.handle, handle, unsafe { nil })
+		return err
+	}
+	require_success(vk.bind_image_memory(device.handle, handle, memory, 0), 'vkBindImageMemory') or {
+		vk.destroy_image(device.handle, handle, unsafe { nil })
+		vk.free_memory(device.handle, memory, unsafe { nil })
+		return err
+	}
+
+	return OwnedImage{
+		device: device.handle
+		handle: handle
+		memory: memory
+		format: format
+		extent: extent
+		tiling: tiling
+		usage: usage
+		allocation_size: requirements.size
+		memory_type_index: memory_type_index
+	}
+}
+
+// destroy first destroys the image, then frees its bound memory. Call it
+// exactly once before destroying the parent Device.
+pub fn (image OwnedImage) destroy() {
+	vk.destroy_image(image.device, image.handle, unsafe { nil })
+	vk.free_memory(image.device, image.memory, unsafe { nil })
+}
+
 // Fence owns a VkFence created by one Device. Its parent device must outlive
 // it. The raw handle remains public for queue submission.
 pub struct Fence {

--- a/ergonomic/ergonomic_test.v
+++ b/ergonomic/ergonomic_test.v
@@ -220,3 +220,50 @@ fn test_select_memory_type_ignores_compatible_disallowed_type() {
 	select_memory_type(properties, u32(0b10), host_visible) or { return }
 	assert false
 }
+
+fn test_new_image_2d_rejects_empty_extent_before_calling_vulkan() {
+	device := Device{
+		handle: vk.Device(unsafe { nil })
+	}
+	usage := u32(vk.ImageUsageFlagBits.sampled)
+	device.new_image_2d(0, 1, .r8g8b8a8_unorm, .optimal, usage, 0) or {
+		assert err.msg() == 'image width and height must be greater than zero'
+		return
+	}
+	assert false
+}
+
+fn test_new_image_2d_rejects_empty_usage_before_calling_vulkan() {
+	device := Device{
+		handle: vk.Device(unsafe { nil })
+	}
+	device.new_image_2d(1, 1, .r8g8b8a8_unorm, .optimal, 0, 0) or {
+		assert err.msg() == 'image usage must not be empty'
+		return
+	}
+	assert false
+}
+
+fn test_owned_image_exposes_creation_and_allocation_metadata() {
+	extent := vk.Extent3D{
+		width: 640
+		height: 480
+		depth: 1
+	}
+	image := OwnedImage{
+		device: vk.Device(unsafe { nil })
+		handle: vk.Image(unsafe { nil })
+		memory: vk.DeviceMemory(unsafe { nil })
+		format: .r8g8b8a8_unorm
+		extent: extent
+		tiling: .optimal
+		usage: u32(vk.ImageUsageFlagBits.sampled)
+		allocation_size: 4096
+		memory_type_index: 2
+	}
+	assert image.format == .r8g8b8a8_unorm
+	assert image.extent.width == 640
+	assert image.extent.height == 480
+	assert image.allocation_size == 4096
+	assert image.memory_type_index == 2
+}


### PR DESCRIPTION
Adds a focused ergonomic 2D image constructor with compatible memory selection, allocation and binding, raw handles and creation metadata, validation, cleanup on partial failure, and correct image-before-memory destruction. Updates tests and API design documentation.