### PR TITLE
Add checked Vulkan queue submission

### DIFF
--- a/API_DESIGN.md
+++ b/API_DESIGN.md
@@ -11,9 +11,9 @@ The generated `vulkan.v` and `vulkan_video.v` files remain the complete, low-lev
 - Two-call enumerations return V arrays and internally retry `VK_INCOMPLETE`.
 - Generated names and signatures are never edited to improve ergonomics. New wrappers compose them from the submodule.
 
-## Discovery, device, buffer, and command slices
+## Discovery through queue submission
 
-The first slice covers loader initialization, default-allocator instance creation and destruction, physical-device enumeration, core property snapshots, and owned device-name strings. The second slice adds queue-family discovery and selection by required `QueueFlags`, plus logical-device creation with one priority-1.0 queue. The third slice adds memory-type selection and buffers which own their bound device-memory allocation. The fourth slice adds owned command pools and primary command buffers:
+The first slice covers loader initialization, default-allocator instance creation and destruction, physical-device enumeration, core property snapshots, and owned device-name strings. Later slices add queue-family and logical-device selection, owned memory-backed buffers and images, command pools and primary command buffers, fences and binary semaphores, and checked queue submission:
 
 ```v
 import antono2.vulkan as vk
@@ -65,7 +65,17 @@ mut image_ready := device.new_semaphore()!
 defer {
 	image_ready.destroy()
 }
-// Submit using fence.handle and image_ready.handle.
+mut render_finished := device.new_semaphore()!
+defer {
+	render_finished.destroy()
+}
+submit_options := vke.SubmitOptions{
+	wait_semaphores: [image_ready]
+	wait_stage_masks: [u32(vk.PipelineStageFlagBits.color_attachment_output)]
+	signal_semaphores: [render_finished]
+	fence: fence
+}
+device.queue.submit([command_buffer], submit_options)!
 println('${physical_device.name()}: queue family ${device.queue.family_index}')
 ```
 
@@ -74,6 +84,8 @@ println('${physical_device.name()}: queue family ${device.queue.family_index}')
 `CommandPool` belongs to its parent `Device` and is fixed to that device's selected queue-family index. `PrimaryCommandBuffer` retains the exact device and pool handles needed by `free()`, while its public raw `handle` remains available for recording and submission. `free()` is idempotent and clears that raw handle. Reset, begin, and end failures are returned as typed `VulkanError` values. Destroying a command pool implicitly frees and invalidates all command buffers still allocated from it; callers may either free buffers explicitly before pool destruction or rely on that Vulkan lifetime rule, but must never use or free a buffer after its pool is destroyed. Every command pool must be destroyed before its parent device.
 
 `Fence` exposes status, timeout-aware waiting, and reset while preserving positive Vulkan statuses such as `VK_NOT_READY` and `VK_TIMEOUT`. `Fence` and `Semaphore` expose their raw handles for submission structures, clear those handles during idempotent destruction, and must be destroyed before their parent device.
+
+`Queue.submit()` accepts a non-empty primary-command-buffer batch plus optional wait semaphores, signal semaphores, and a fence. Every wait semaphore requires a pipeline-stage mask at the same array index; mismatched counts are rejected before Vulkan is called. The helper keeps all temporary raw-handle arrays alive through `vkQueueSubmit`, passes a null fence when none is supplied, returns non-negative Vulkan statuses unchanged, and converts failures to `VulkanError`.
 
 `OwnedImage` creates a simple exclusive-sharing 2D image with one mip level, one array layer, and one sample. It exposes the raw image and memory handles plus its format, extent, tiling, usage, allocation size, and selected memory type. Destruction releases the image before its bound allocation, and must happen before destroying the parent device. More specialized image creation remains available through the raw layer.
 
@@ -86,4 +98,5 @@ Custom allocation callbacks, concurrent-sharing buffers, queue priorities other 
 3. Configurable queue requests, extension validation, and enabled features.
 4. Owned fences and binary semaphores with explicit parent ownership and destruction ordering. (Implemented.)
 5. Owned 2D images with explicit parent ownership and destruction ordering. (Implemented.)
-6. Builders only where they eliminate unsafe pointer/count bookkeeping; Vulkan synchronization and memory choices should remain explicit.
+6. Checked primary command-buffer queue submission with explicit synchronization. (Implemented.)
+7. Builders only where they eliminate unsafe pointer/count bookkeeping; Vulkan synchronization and memory choices should remain explicit.

--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ The generated module remains the complete low-level binding. The opt-in
 `antono2.vulkan.ergonomic` submodule adds typed errors, instance lifecycle
 helpers, physical-device and queue-family discovery, and single-queue logical
 device ownership. It also provides explicit memory-type selection and owned
-buffer/device-memory allocation, plus owned command pools and primary command
-buffer lifecycle helpers, without modifying generated files.
+buffer/device-memory allocation, owned command pools and primary command-buffer
+lifecycle helpers, synchronization objects, and checked queue submission without
+modifying generated files.
 See [the ergonomic API design](API_DESIGN.md).
 
 ## Generate

--- a/ergonomic/ergonomic.v
+++ b/ergonomic/ergonomic.v
@@ -564,6 +564,57 @@ pub fn (mut semaphore Semaphore) destroy() {
 	semaphore.handle = vk.Semaphore(unsafe { nil })
 }
 
+// SubmitOptions describes the synchronization attached to one queue
+// submission. Each wait semaphore must have a stage mask at the same index.
+// An absent fence passes VK_NULL_HANDLE to Vulkan.
+pub struct SubmitOptions {
+pub:
+	wait_semaphores   []Semaphore
+	wait_stage_masks  []vk.PipelineStageFlags
+	signal_semaphores []Semaphore
+	fence             ?Fence
+}
+
+// submit submits one non-empty batch of primary command buffers. It owns the
+// temporary raw-handle arrays for the duration of vkQueueSubmit and preserves
+// both typed Vulkan failures and non-negative result statuses.
+pub fn (queue Queue) submit(command_buffers []PrimaryCommandBuffer, options SubmitOptions) !vk.Result {
+	if command_buffers.len == 0 {
+		return error('queue submission requires at least one command buffer')
+	}
+	if options.wait_semaphores.len != options.wait_stage_masks.len {
+		return error('wait semaphore count must match wait stage mask count')
+	}
+
+	mut command_handles := []vk.CommandBuffer{cap: command_buffers.len}
+	for command_buffer in command_buffers {
+		command_handles << command_buffer.handle
+	}
+	mut wait_handles := []vk.Semaphore{cap: options.wait_semaphores.len}
+	for semaphore in options.wait_semaphores {
+		wait_handles << semaphore.handle
+	}
+	mut signal_handles := []vk.Semaphore{cap: options.signal_semaphores.len}
+	for semaphore in options.signal_semaphores {
+		signal_handles << semaphore.handle
+	}
+
+	submit_info := vk.SubmitInfo{
+		waitSemaphoreCount: u32(wait_handles.len)
+		pWaitSemaphores: wait_handles.data
+		pWaitDstStageMask: options.wait_stage_masks.data
+		commandBufferCount: u32(command_handles.len)
+		pCommandBuffers: command_handles.data
+		signalSemaphoreCount: u32(signal_handles.len)
+		pSignalSemaphores: signal_handles.data
+	}
+	mut fence_handle := vk.Fence(unsafe { nil })
+	if fence := options.fence {
+		fence_handle = fence.handle
+	}
+	return check(vk.queue_submit(queue.handle, 1, &submit_info, fence_handle), 'vkQueueSubmit')
+}
+
 // physical_devices performs Vulkan's count/fill enumeration pattern and
 // retries when the available device set changes and VK_INCOMPLETE is returned.
 pub fn (instance Instance) physical_devices() ![]PhysicalDevice {

--- a/ergonomic/ergonomic_test.v
+++ b/ergonomic/ergonomic_test.v
@@ -174,6 +174,64 @@ fn test_sync_destroy_is_idempotent_for_cleared_handles() {
 	assert isnil(semaphore.handle)
 }
 
+fn test_queue_submit_rejects_empty_command_list_before_calling_vulkan() {
+	queue := Queue{
+		handle: vk.Queue(unsafe { nil })
+	}
+	queue.submit([], SubmitOptions{}) or {
+		assert err.msg() == 'queue submission requires at least one command buffer'
+		return
+	}
+	assert false
+}
+
+fn test_queue_submit_rejects_mismatched_waits_and_stage_masks() {
+	queue := Queue{
+		handle: vk.Queue(unsafe { nil })
+	}
+	command_buffer := PrimaryCommandBuffer{
+		handle: vk.CommandBuffer(unsafe { nil })
+	}
+	wait_semaphore := Semaphore{
+		handle: vk.Semaphore(unsafe { nil })
+	}
+	options := SubmitOptions{
+		wait_semaphores: [wait_semaphore]
+	}
+	queue.submit([command_buffer], options) or {
+		assert err.msg() == 'wait semaphore count must match wait stage mask count'
+		return
+	}
+	assert false
+}
+
+fn test_submit_options_accept_matching_waits_signals_and_optional_fence() {
+	wait_semaphore := Semaphore{
+		handle: vk.Semaphore(unsafe { nil })
+	}
+	signal_semaphore := Semaphore{
+		handle: vk.Semaphore(unsafe { nil })
+	}
+	fence := Fence{
+		handle: vk.Fence(unsafe { nil })
+	}
+	stage := u32(vk.PipelineStageFlagBits.color_attachment_output)
+	options := SubmitOptions{
+		wait_semaphores: [wait_semaphore]
+		wait_stage_masks: [stage]
+		signal_semaphores: [signal_semaphore]
+		fence: fence
+	}
+	assert options.wait_semaphores.len == 1
+	assert options.wait_stage_masks == [stage]
+	assert options.signal_semaphores.len == 1
+	if configured_fence := options.fence {
+		assert configured_fence.handle == fence.handle
+	} else {
+		assert false
+	}
+}
+
 fn memory_properties(types []vk.MemoryPropertyFlags) vk.PhysicalDeviceMemoryProperties {
 	mut properties := vk.PhysicalDeviceMemoryProperties{
 		memoryTypeCount: u32(types.len)

--- a/ergonomic/ergonomic_test.v
+++ b/ergonomic/ergonomic_test.v
@@ -223,7 +223,8 @@ fn test_submit_options_accept_matching_waits_signals_and_optional_fence() {
 		fence: fence
 	}
 	assert options.wait_semaphores.len == 1
-	assert options.wait_stage_masks == [stage]
+	assert options.wait_stage_masks.len == 1
+	assert options.wait_stage_masks[0] == stage
 	assert options.signal_semaphores.len == 1
 	if configured_fence := options.fence {
 		assert configured_fence.handle == fence.handle


### PR DESCRIPTION
## Summary
- add `Queue.submit` for primary command buffers with optional waits, signals, and fence
- validate non-empty command batches and matching wait semaphore/stage-mask counts
- preserve raw Vulkan statuses and typed `VulkanError` failures
- document submission usage and cover validation without invoking Vulkan

## Local checks
- `v fmt -verify ergonomic/ergonomic.v ergonomic/ergonomic_test.v`
- `v -check-syntax ergonomic`
- `git diff --check`

Compilation is delegated to GitHub Actions.