### PR TITLE
Remove deprecated Vulkan CI downloader

### DIFF
--- a/.github/scripts/setup-vulkan-ci.sh
+++ b/.github/scripts/setup-vulkan-ci.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+sdk_version="${1:?usage: setup-vulkan-ci.sh SDK_VERSION ARTIFACT_TAG}"
+artifact_tag="${2:?usage: setup-vulkan-ci.sh SDK_VERSION ARTIFACT_TAG}"
+install_root="${RUNNER_TEMP:?}"
+install_root="${install_root//\\//}/vulkan-ci"
+
+case "${RUNNER_OS:?}" in
+	Linux)
+		artifact_platform='ubuntu-20.04-x64'
+		swiftshader_library='libvk_swiftshader.so'
+		;;
+	macOS)
+		artifact_platform='macOS-13-x64'
+		swiftshader_library='libvk_swiftshader.dylib'
+		;;
+	Windows)
+		artifact_platform='windows-2022-x64'
+		swiftshader_library='vk_swiftshader.dll'
+		;;
+	*)
+		echo "unsupported runner OS: $RUNNER_OS" >&2
+		exit 1
+		;;
+esac
+
+sdk_archive="vulkanSDK-${sdk_version}-${artifact_platform}.zip"
+swiftshader_archive="swiftshader-${artifact_platform}.zip"
+download_base="https://github.com/NcStudios/VulkanCI/releases/download/${artifact_tag}"
+sdk_root="$install_root/VulkanSDK"
+swiftshader_root="$install_root/swiftshader"
+
+mkdir -p "$sdk_root" "$swiftshader_root"
+curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
+	"$download_base/$sdk_archive" --output "$install_root/$sdk_archive"
+curl --fail --location --retry 5 --retry-all-errors --silent --show-error \
+	"$download_base/$swiftshader_archive" --output "$install_root/$swiftshader_archive"
+if command -v python3 >/dev/null 2>&1; then
+	archive_python='python3'
+elif command -v python >/dev/null 2>&1; then
+	archive_python='python'
+else
+	echo 'Python is required to extract Vulkan CI artifacts' >&2
+	exit 1
+fi
+"$archive_python" -m zipfile -e "$install_root/$sdk_archive" "$sdk_root"
+"$archive_python" -m zipfile -e "$install_root/$swiftshader_archive" "$swiftshader_root"
+
+sdk_path="$sdk_root/$sdk_version"
+test -d "$sdk_path/include"
+test -f "$swiftshader_root/$swiftshader_library"
+
+driver_manifest="$swiftshader_root/vk_swiftshader_icd.json"
+cat > "$driver_manifest" <<EOF
+{
+  "file_format_version": "1.0.0",
+  "ICD": {
+    "library_path": "$swiftshader_root/$swiftshader_library",
+    "api_version": "1.0.5"
+  }
+}
+EOF
+
+{
+	echo "VULKAN_SDK=$sdk_path"
+	echo "VULKAN_SDK_VERSION=$sdk_version"
+	echo "VK_DRIVER_FILES=$driver_manifest"
+} >> "${GITHUB_ENV:?}"
+
+case "$RUNNER_OS" in
+	Linux)
+		library_path="$sdk_path/lib:$swiftshader_root"
+		if [[ -n "${LD_LIBRARY_PATH:-}" ]]; then
+			library_path="$LD_LIBRARY_PATH:$library_path"
+		fi
+		{
+			echo "VK_LAYER_PATH=$sdk_path/share/vulkan/explicit_layer.d"
+			echo "LD_LIBRARY_PATH=$library_path"
+		} >> "$GITHUB_ENV"
+		;;
+	macOS)
+		library_path="$sdk_path/lib:$swiftshader_root"
+		if [[ -n "${DYLD_LIBRARY_PATH:-}" ]]; then
+			library_path="$DYLD_LIBRARY_PATH:$library_path"
+		fi
+		{
+			echo "VK_LAYER_PATH=$sdk_path/share/vulkan/explicit_layer.d"
+			echo "DYLD_LIBRARY_PATH=$library_path"
+		} >> "$GITHUB_ENV"
+		;;
+	Windows)
+		echo "VK_LAYER_PATH=$sdk_path/bin" >> "$GITHUB_ENV"
+		echo "$sdk_path/bin" >> "${GITHUB_PATH:?}"
+		;;
+esac

--- a/.github/workflows/generated-bindings-ci.yml
+++ b/.github/workflows/generated-bindings-ci.yml
@@ -123,10 +123,10 @@ jobs:
           make -C .ci-v-master
           echo "$GITHUB_WORKSPACE/.ci-v-master" >> "$GITHUB_PATH"
           .ci-v-master/v -V
-      - uses: NcStudios/VulkanCI@v1.2
+      - name: Install Vulkan SDK and SwiftShader test artifacts
         if: matrix.v-channel != 'master' || steps.setup_v_master.outcome == 'success'
-        with:
-          sdkVersion: 1.4.309.0
+        shell: bash
+        run: bash .github/scripts/setup-vulkan-ci.sh 1.4.309.0 v1.2
       - name: Install registry-matched headers and pinned Volk
         if: matrix.v-channel != 'master' || steps.setup_v_master.outcome == 'success'
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ in `VERSION`.
 - Legacy nonzero queue indices now request every Vulkan queue through the
   selected index before retrieving that queue.
 
+### Changed
+
+- Install the pinned Vulkan SDK and SwiftShader CI artifacts without the
+  deprecated Node 20 release-downloader action.
+
 ## 1.5.0 - 2026-09-08
 
 ### Added


### PR DESCRIPTION
## Summary

- replace `NcStudios/VulkanCI@v1.2`, whose composite action still invokes the deprecated Node 20 `robinraju/release-downloader@v1.10`
- download the exact same pinned Vulkan SDK 1.4.309.0 and SwiftShader `v1.2` artifacts directly
- reproduce the existing Linux, macOS, and Windows Vulkan environment without another JavaScript action
- keep the setup helper non-executable and invoke it explicitly with Bash

## Validation

- `bash -n .github/scripts/setup-vulkan-ci.sh`
- parsed the workflow with Ruby Psych
- downloaded and extracted the Linux SDK and SwiftShader artifacts locally
- verified the emitted `VULKAN_SDK`, driver manifest, layer, and library paths
- full GitHub matrix will exercise Linux, macOS, and Windows
