### PR TITLE
Prepare Vulkan 1.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This changelog tracks the semantic version of the V module in `v.mod`.
 Generated binding snapshots continue to use the Vulkan registry version stored
 in `VERSION`.
 
-## Unreleased
+## 1.6.0 - 2026-09-09
 
 ### Added
 

--- a/v.mod
+++ b/v.mod
@@ -2,7 +2,7 @@ Module {
 	name: 'antono2.vulkan'
 	author: 'Anton Oreskin'
 	description: 'V Vulkan Bindings'
-	version: '1.5.0'
+	version: '1.6.0'
 	repo_url: 'https://github.com/antono2/vulkan'
 	vcs: 'git'
 	tags: ['V','vulkan','graphics']


### PR DESCRIPTION
## Summary

- promote the completed multi-queue work from Unreleased to Vulkan module 1.6.0
- bump only the semantic package version in `v.mod`
- retain the generated Vulkan registry snapshot at `v1.4.362`

## Included

- validated multi-family queue requests and per-queue priorities
- corrected legacy nonzero queue creation
- queue-specific command pools
- Node 20-free cross-platform Vulkan SDK CI setup

All implementation and cross-platform checks passed in #21 and #22; this PR changes release metadata only.
